### PR TITLE
refactor: stringify to link

### DIFF
--- a/stockalert/entity/sku.py
+++ b/stockalert/entity/sku.py
@@ -18,13 +18,13 @@ class Sku:
 
 class AvailableSku(Sku):
     def __init__(self, *init, **kwargs):
-        self.stringify = None
+        self.link = None
         self.price = None
         super(AvailableSku, self).__init__(*init, **kwargs)
-        assert self.stringify is not None
+        assert self.link is not None
 
     def __str__(self):
-        return f"{self.shortname} {self.stringify(self)}"
+        return f"{self.shortname} {self.link}"
 
     def __repr__(self):
         return str(self)

--- a/stockalert/retailerclient/bbclient.py
+++ b/stockalert/retailerclient/bbclient.py
@@ -53,6 +53,6 @@ def filter_by_availability(skus: List[Sku]) -> List[AvailableSku]:
     sku_dict: dict = {sku.identifier: sku for sku in skus}
     availabilities = lookup(skus)
 
-    return [AvailableSku(sku_dict[x["sku"]], stringify=get_bb_product_link)
+    return [AvailableSku(sku_dict[x["sku"]], link=get_bb_product_link(x))
             for x in availabilities
             if is_available(x)]

--- a/stockalert/retailerclient/caldigit.py
+++ b/stockalert/retailerclient/caldigit.py
@@ -57,10 +57,7 @@ def _filter_by_availability(skus: List[Sku], url: str) -> List[AvailableSku]:
     available_product_map = {k: v for k, v in product_map.items() if v.get("available")}
 
     def merge(sku: Sku, product: dict) -> AvailableSku:
-        def stringify(_):
-            return product.get("link")
-
-        return AvailableSku(sku, price=product.get("price"), stringify=stringify)
+        return AvailableSku(sku, price=product.get("price"), link=product.get("link"))
 
     return [
         merge(sku, available_product_map[sku.identifier])

--- a/stockalert/retailerclient/memoryExpressClient.py
+++ b/stockalert/retailerclient/memoryExpressClient.py
@@ -38,7 +38,7 @@ def process_single_sku(sku: Sku) -> AvailableSku:
         for store in stores:
             text = store.text
             if ("Edmonton" in text and "Out" not in text):
-                return AvailableSku(sku, stringify=get_memory_express_product_link)
+                return AvailableSku(sku, link=get_memory_express_product_link(sku))
     else:
         logger.info("Memory express changed their store classname! Please update the store/stock query")
 


### PR DESCRIPTION
change `stringify` to `link`. 
The string representation of a SKU is always going to be the product link. 